### PR TITLE
feat(updaloadManager): add upload manager

### DIFF
--- a/application/services/upload_manager.go
+++ b/application/services/upload_manager.go
@@ -1,0 +1,133 @@
+package services
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"cloud.google.com/go/storage"
+)
+
+type VideoUpload struct {
+	Paths        []string
+	VideoPath    string
+	OutputBucket string
+	Errors       []string
+}
+
+func NewVideoUpload() *VideoUpload {
+	return &VideoUpload{}
+}
+
+func (vu *VideoUpload) UploadObject(objectPath string, client *storage.Client, ctx context.Context) error {
+
+	path := strings.Split(objectPath, os.Getenv("localStoragePath")+"/")
+
+	f, err := os.Open(objectPath)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	wc := client.Bucket(vu.OutputBucket).Object(path[1]).NewWriter(ctx)
+	wc.ACL = []storage.ACLRule{{Entity: storage.AllUsers, Role: storage.RoleReader}}
+
+	_, err = io.Copy(wc, f)
+	if err != nil {
+		return err
+	}
+
+	err = wc.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (vu *VideoUpload) loadPaths() error {
+
+	err := filepath.Walk(vu.VideoPath, func(path string, info os.FileInfo, err error) error {
+
+		if !info.IsDir() {
+			vu.Paths = append(vu.Paths, path)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (vu *VideoUpload) ProcessUpload(concurrency int, doneUpload chan string) error {
+
+	in := make(chan int, runtime.NumCPU())
+	returnChannel := make(chan string)
+
+	err := vu.loadPaths()
+	if err != nil {
+		return err
+	}
+
+	uploadClient, ctx, err := getClientUpload()
+	if err != nil {
+		return err
+	}
+
+	for process := 0; process < concurrency; process++ {
+		go vu.uploadWorker(in, returnChannel, uploadClient, ctx)
+	}
+
+	go func() {
+		for x := 0; x < len(vu.Paths); x++ {
+			in <- x
+		}
+		close(in)
+	}()
+
+	for rc := range returnChannel {
+		if rc != "" {
+			doneUpload <- rc
+			break
+		}
+	}
+
+	return nil
+}
+
+func (vu *VideoUpload) uploadWorker(in chan int, returnChan chan string, uploadClient *storage.Client, ctx context.Context) {
+
+	for x := range in {
+		err := vu.UploadObject(vu.Paths[x], uploadClient, ctx)
+
+		if err != nil {
+			vu.Errors = append(vu.Errors, vu.Paths[x])
+			log.Printf("error during the upload: %v. Error: %v", vu.Paths[x], err)
+			returnChan <- err.Error()
+		}
+
+		returnChan <- ""
+	}
+
+	returnChan <- "upload completed"
+}
+
+func getClientUpload() (*storage.Client, context.Context, error) {
+
+	ctx := context.Background()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, ctx, nil
+}

--- a/application/services/upload_manager_test.go
+++ b/application/services/upload_manager_test.go
@@ -1,0 +1,48 @@
+package services_test
+
+import (
+	"dnogueir-org/video-encoder/application/services"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	err := godotenv.Load("../../.env")
+	if err != nil {
+		log.Fatalf("Error loading .env file")
+	}
+}
+
+func TestVideoServiceUpload(t *testing.T) {
+	video, repo := prepare()
+	videoService := services.NewVideoService()
+	videoService.Video = video
+	videoService.VideoRepository = repo
+
+	bucketName := "video-encoder-bucket"
+	err := videoService.Download(bucketName)
+	require.Nil(t, err)
+
+	err = videoService.Fragment()
+	require.Nil(t, err)
+
+	err = videoService.Encode()
+	require.Nil(t, err)
+
+	videoUpload := services.NewVideoUpload()
+	videoUpload.OutputBucket = "video-encoder-bucket"
+	videoUpload.VideoPath = os.Getenv("localStoragePath") + "/" + video.ID
+
+	doneUpload := make(chan string)
+	go videoUpload.ProcessUpload(20, doneUpload)
+
+	result := <-doneUpload
+	require.Equal(t, "upload completed", result)
+
+	err = videoService.Finish()
+	require.Nil(t, err)
+}


### PR DESCRIPTION
## What
Adding upload manager

## Why
So we can upload the fragmented video to GCP

## How
By creating a method to handle the upload of 1 object and several go routines to create connections to GCP and upload the files in parallel